### PR TITLE
fix: resolve execute_sql AttributeError, default warehouse_id from env

### DIFF
--- a/src/server/databricks_mcp_server.py
+++ b/src/server/databricks_mcp_server.py
@@ -192,17 +192,17 @@ class DatabricksMCPServer(FastMCP):
         # SQL tools
         @self.tool(
             name="execute_sql",
-            description="Execute a SQL statement with parameters: statement (required), warehouse_id (required), catalog (optional), schema (optional)",
+            description="Execute a SQL statement with parameters: statement (required), warehouse_id (optional, defaults to DATABRICKS_SQL_WAREHOUSE_ID env var), catalog (optional), schema (optional)",
         )
         async def execute_sql(params: Dict[str, Any]) -> List[TextContent]:
             logger.info(f"Executing SQL with params: {params}")
             try:
                 statement = params.get("statement")
-                warehouse_id = params.get("warehouse_id")
+                warehouse_id = params.get("warehouse_id") or os.environ.get("DATABRICKS_SQL_WAREHOUSE_ID")
                 catalog = params.get("catalog")
                 schema = params.get("schema")
                 
-                result = await sql.execute_sql(statement, warehouse_id, catalog, schema)
+                result = await sql.execute_and_wait(statement, warehouse_id, catalog, schema)
                 return [{"text": json.dumps(result)}]
             except Exception as e:
                 logger.error(f"Error executing SQL: {str(e)}")


### PR DESCRIPTION
This PR address an issue and offers an enhancement:

## Bug Fix

- The `execute_sql` tool called `sql.execute_sql()`, which doesn't exist in `src/api/sql.py`. This caused: `{"error": "module 'src.api.sql' has no attribute 'execute_sql'"}`
- Changed to `sql.execute_and_wait()` which polls for query completion and returns results.

## Enhancement

- Made `warehouse_id` optional by falling back to the `DATABRICKS_SQL_WAREHOUSE_ID` environment variable. This lets users configure it once in their MCP server config (e.g. `claude_desktop_config.json`) rather than passing it on every call.

